### PR TITLE
DS-5170 Make consent optional

### DIFF
--- a/gdpr_consent.install
+++ b/gdpr_consent.install
@@ -12,6 +12,9 @@ use Drupal\gdpr_consent\Entity\DataPolicy;
  * Implements hook_install().
  */
 function gdpr_consent_install() {
+  // Hide a message about a new version of data policy for the anonymous user.
+  user_role_grant_permissions('anonymous', ['without consent']);
+
   $data_policy = DataPolicy::create([
     'name' => 'Data policy',
     'field_description' => [

--- a/gdpr_consent.module
+++ b/gdpr_consent.module
@@ -8,7 +8,6 @@
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\gdpr_consent\Form\DataPolicyAgreement;
 
 /**
  * Implements hook_help().
@@ -64,10 +63,7 @@ function gdpr_consent_theme($existing, $type, $theme, $path) {
  * Implements hook_form_FORM_ID_alter().
  */
 function gdpr_consent_form_user_register_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $enforce_consent = \Drupal::config('gdpr_consent.data_policy')
-    ->get('enforce_consent');
-
-  DataPolicyAgreement::addCheckbox($form, !empty($enforce_consent));
+  \Drupal::service('gdpr_consent.manager')->addCheckbox($form);
 
   $form['actions']['submit']['#submit'][] = '_gdpr_consent_user_register_form_submit';
 }
@@ -81,7 +77,6 @@ function gdpr_consent_form_user_register_form_alter(&$form, FormStateInterface $
  *   The current state of the form.
  */
 function _gdpr_consent_user_register_form_submit(array &$form, FormStateInterface $form_state) {
-  if (!empty($form_state->getValue('data_policy'))) {
-    DataPolicyAgreement::saveConsent($form_state->getValue('uid'));
-  }
+  $values = $form_state->getValues();
+  \Drupal::service('gdpr_consent.manager')->saveConsent($values['uid'], !empty($values['data_policy']));
 }

--- a/gdpr_consent.services.yml
+++ b/gdpr_consent.services.yml
@@ -4,6 +4,6 @@ services:
     arguments: ['@config.factory', '@current_user', '@entity_type.manager']
   gdpr_consent.redirect_subscriber:
     class: Drupal\gdpr_consent\RedirectSubscriber
-    arguments: ['@current_route_match', '@gdpr_consent.manager', '@redirect.destination']
+    arguments: ['@current_route_match', '@redirect.destination', '@current_user', '@config.factory', '@entity_type.manager']
     tags:
       - { name: event_subscriber }

--- a/gdpr_consent.services.yml
+++ b/gdpr_consent.services.yml
@@ -4,6 +4,6 @@ services:
     arguments: ['@config.factory', '@current_user', '@entity_type.manager']
   gdpr_consent.redirect_subscriber:
     class: Drupal\gdpr_consent\RedirectSubscriber
-    arguments: ['@current_route_match', '@redirect.destination', '@current_user', '@config.factory', '@entity_type.manager']
+    arguments: ['@current_route_match', '@redirect.destination', '@current_user', '@config.factory', '@entity_type.manager', '@messenger']
     tags:
       - { name: event_subscriber }

--- a/src/Controller/DataPolicyController.php
+++ b/src/Controller/DataPolicyController.php
@@ -93,6 +93,7 @@ class DataPolicyController extends ControllerBase implements ContainerInjectionI
         '#theme' => 'table',
         '#header' => [
           $this->t('User'),
+          $this->t('Agreed'),
           $this->t('Date and time'),
         ],
       ];
@@ -101,6 +102,7 @@ class DataPolicyController extends ControllerBase implements ContainerInjectionI
       foreach ($user_consents as $user_consent) {
         $build['user_consent']['list']['#rows'][] = [
           $user_consent->getOwner()->getDisplayName(),
+          $user_consent->isPublished() ? $this->t('Yes') : $this->t('No'),
           $this->dateFormatter()->format($user_consent->getChangedTime(), 'short'),
         ];
       }

--- a/src/Entity/UserConsent.php
+++ b/src/Entity/UserConsent.php
@@ -31,6 +31,7 @@ use Drupal\user\UserInterface;
  *     "uuid" = "uuid",
  *     "uid" = "user_id",
  *     "langcode" = "langcode",
+ *     "status" = "status",
  *   },
  *   links = {
  *     "collection" = "/admin/reports/user-consents",
@@ -104,13 +105,14 @@ class UserConsent extends ContentEntityBase implements UserConsentInterface {
    * {@inheritdoc}
    */
   public function isPublished() {
-    return TRUE;
+    return (bool) $this->getEntityKey('status');
   }
 
   /**
    * {@inheritdoc}
    */
   public function setPublished($published) {
+    $this->set('status', $published ? TRUE : FALSE);
     return $this;
   }
 
@@ -161,6 +163,12 @@ class UserConsent extends ContentEntityBase implements UserConsentInterface {
       ->setLabel(new TranslatableMarkup('Data policy revision ID'))
       ->setReadOnly(TRUE)
       ->setSetting('unsigned', TRUE);
+
+    $fields['status'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Consent status'))
+      ->setDescription(t('A boolean indicating whether user gave consent on data policy revision.'))
+      ->setRevisionable(TRUE)
+      ->setDefaultValue(TRUE);
 
     $fields['created'] = BaseFieldDefinition::create('created')
       ->setLabel(t('Created'))

--- a/src/Form/DataPolicyAgreement.php
+++ b/src/Form/DataPolicyAgreement.php
@@ -2,12 +2,8 @@
 
 namespace Drupal\gdpr_consent\Form;
 
-use Drupal\Component\Serialization\Json;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Link;
-use Drupal\gdpr_consent\Entity\DataPolicy;
-use Drupal\gdpr_consent\Entity\UserConsent;
 
 /**
  * Class DataPolicyAgreement.
@@ -27,7 +23,7 @@ class DataPolicyAgreement extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    static::addCheckbox($form);
+    \Drupal::service('gdpr_consent.manager')->addCheckbox($form);
 
     $form['actions']['#type'] = 'actions';
 
@@ -43,61 +39,14 @@ class DataPolicyAgreement extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    static::saveConsent($this->currentUser()->id());
+    \Drupal::service('gdpr_consent.manager')->saveConsent(
+      $this->currentUser()->id(),
+      !empty($form_state->getValue('data_policy'))
+    );
 
     if (\Drupal::destination()->get() == '/data-policy-agreement') {
       $form_state->setRedirect('<front>');
     }
-  }
-
-  /**
-   * Add checkbox to form which allow user give consent on data policy.
-   *
-   * @param array $form
-   *   An associative array containing the structure of the form.
-   * @param bool $required
-   *   TRUE if the field should be required.
-   */
-  public static function addCheckbox(array &$form, $required = TRUE) {
-    $form['#attached']['library'][] = 'core/drupal.dialog.ajax';
-
-    $link = Link::createFromRoute(t('data policy'), 'gdpr_consent.data_policy', [], [
-      'attributes' => [
-        'class' => ['use-ajax'],
-        'data-dialog-type' => 'modal',
-        'data-dialog-options' => Json::encode([
-          'title' => t('Data policy'),
-          'width' => 700,
-          'height' => 700,
-        ]),
-      ],
-    ]);
-
-    $form['data_policy'] = [
-      '#type' => 'checkbox',
-      '#title' => t('I agree with the @url', [
-        '@url' => $link->toString(),
-      ]),
-      '#required' => $required,
-    ];
-  }
-
-  /**
-   * Save user consent.
-   *
-   * @param int $user_id
-   *   The user ID.
-   */
-  public static function saveConsent($user_id) {
-    $user_consent = UserConsent::create();
-
-    $user_consent->setOwnerId($user_id);
-
-    $entity_id = \Drupal::config('gdpr_consent.data_policy')->get('entity_id');
-
-    $user_consent->setRevision(DataPolicy::load($entity_id));
-
-    $user_consent->save();
   }
 
 }

--- a/src/GdprConsentManagerInterface.php
+++ b/src/GdprConsentManagerInterface.php
@@ -15,4 +15,22 @@ interface GdprConsentManagerInterface {
    */
   public function needConsent();
 
+  /**
+   * Add checkbox to form which allow user give consent on data policy.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   */
+  public function addCheckbox(array &$form);
+
+  /**
+   * Save user consent.
+   *
+   * @param int $user_id
+   *   The user ID.
+   * @param bool $agree
+   *   The status of user consent entity.
+   */
+  public function saveConsent($user_id, $agree);
+
 }

--- a/src/RedirectSubscriber.php
+++ b/src/RedirectSubscriber.php
@@ -150,7 +150,7 @@ class RedirectSubscriber implements EventSubscriberInterface {
     if (!$enforce_consent) {
       $link = Link::createFromRoute($this->t('here'), 'gdpr_consent.data_policy.agreement');
 
-      $this->messenger->addStatus($this->t('We published a new revision of the data policy. You can review the data policy @url.', [
+      $this->messenger->addStatus($this->t('We published a new version of the data policy. You can review the data policy @url.', [
         '@url' => $link->toString(),
       ]));
 


### PR DESCRIPTION
## HTT
- [x] When you log in as X then you should see the following message **We published a new version of the data policy. You can review the data policy here.**
- [x] When you click **here** in that message then you should be on the **Data policy agreement** page
- [x] You should see that the **I agree with the data policy** checkbox is optional
- [x] Press **Save** and you should be redirected to the homepage
- [x] You should not see the following message **We published a new version of the data policy. You can review the data policy here.**
- [x] Log in as administrator and go to **/admin/config/people/data-policy/1**
- [x] You should see one row in the **USER CONSENTS FOR CURRENT REVISION** table and you should see **No** in the **Agreed** column
- [x] Go to **/admin/structure/data_policy/settings**
- [x] Set **Enforce consent** checkbox and press **Save configuration**
- [x] When you log in as X again then you should be on the **Data policy agreement** page
- [x] You should see that the **I agree with the data policy** checkbox is required
- [x] Set **I agree with the data policy** checkbox and press **Save**
- [x] Log in as administrator and go to **/admin/config/people/data-policy/1**
- [x] You should see two row in the **USER CONSENTS FOR CURRENT REVISION** table and you should see **Yes** in the **Agreed** column of a new row