### PR TITLE
Issue #3057405: Capitalize the name of the module in .info.yml file.

### DIFF
--- a/data_policy.info.yml
+++ b/data_policy.info.yml
@@ -1,4 +1,4 @@
-name: Data policy
+name: Data Policy
 description: Create data policies and track user agreements as well as informing users.
 core: 8.x
 configure: entity.informblock.collection


### PR DESCRIPTION
### Problem
Capitalize the name of the module, because module names are proper nouns.

### Solution
Capitalize the name of the module in .info.yml file

### Links
- https://www.drupal.org/project/data_policy/issues/3057405