### PR TITLE
#3059927 - Make it possible to alter the redirect destination

### DIFF
--- a/data_policy.api.php
+++ b/data_policy.api.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Documentation for Data Policy API.
+ */
+
+/**
+ * Alter the data policy destination before performing the redirect.
+ *
+ * @param \Drupal\Core\Routing\RedirectDestinationInterface $destination
+ *   The original destination parameter.
+ *
+ * @return \Drupal\Core\Routing\RedirectDestinationInterface
+ *   An altered data policy destination url.
+ */
+function hook_data_policy_destination_alter(\Drupal\Core\Routing\RedirectDestinationInterface $destination) {
+  return $destination;
+}

--- a/data_policy.api.php
+++ b/data_policy.api.php
@@ -8,12 +8,17 @@
 /**
  * Alter the data policy destination before performing the redirect.
  *
+ * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+ *   The current user.
  * @param \Drupal\Core\Routing\RedirectDestinationInterface $destination
  *   The original destination parameter.
  *
  * @return \Drupal\Core\Routing\RedirectDestinationInterface
  *   An altered data policy destination url.
  */
-function hook_data_policy_destination_alter(\Drupal\Core\Routing\RedirectDestinationInterface $destination) {
+function hook_data_policy_destination_alter(\Drupal\Core\Session\AccountProxyInterface $current_user, \Drupal\Core\Routing\RedirectDestinationInterface $destination) {
+  if ($current_user->isAnonymous()) {
+    $destination->set('/user/login');
+  }
   return $destination;
 }

--- a/data_policy.module
+++ b/data_policy.module
@@ -36,6 +36,16 @@ function data_policy_help($route_name, RouteMatchInterface $route_match) {
 }
 
 /**
+ * Implements hook_hook_info().
+ */
+function data_policy_hook_info() {
+  $hooks = array(
+    'data_policy_destination_alter',
+  );
+  return array_fill_keys($hooks, array('group' => 'data_policy'));
+}
+
+/**
  * Implements hook_theme().
  */
 function data_policy_theme($existing, $type, $theme, $path) {

--- a/data_policy.services.yml
+++ b/data_policy.services.yml
@@ -4,6 +4,6 @@ services:
     arguments: ['@config.factory', '@current_user', '@entity_type.manager']
   data_policy.redirect_subscriber:
     class: Drupal\data_policy\RedirectSubscriber
-    arguments: ['@current_route_match', '@redirect.destination', '@current_user', '@config.factory', '@entity_type.manager', '@messenger', '@data_policy.manager']
+    arguments: ['@current_route_match', '@redirect.destination', '@current_user', '@config.factory', '@entity_type.manager', '@messenger', '@data_policy.manager', '@module_handler']
     tags:
       - { name: event_subscriber }

--- a/src/RedirectSubscriber.php
+++ b/src/RedirectSubscriber.php
@@ -116,15 +116,20 @@ class RedirectSubscriber implements EventSubscriberInterface {
    *
    * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
    *   The event.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function checkForRedirection(GetResponseEvent $event) {
+  public function checkForRedirection(GetResponseEvent $event): void {
+    // Check if a data policy is set.
     if (!$this->dataPolicyConsentManager->isDataPolicy()) {
       return;
     }
 
-    $route_name = $this->routeMatch->getRouteName();
-
-    if ($route_name == 'data_policy.data_policy.agreement') {
+    // Check if the current route is the data policy agreement page.
+    if (($route_name = $this->routeMatch->getRouteName()) === 'data_policy.data_policy.agreement') {
+      // The current route is the data policy agreement page. We don't need
+      // a redirect response.
       return;
     }
 
@@ -184,7 +189,7 @@ class RedirectSubscriber implements EventSubscriberInterface {
       'user.logout',
     ];
 
-    if (in_array($route_name, $route_names)) {
+    if (in_array($route_name, $route_names, TRUE)) {
       return;
     }
 

--- a/src/RedirectSubscriber.php
+++ b/src/RedirectSubscriber.php
@@ -182,11 +182,13 @@ class RedirectSubscriber implements EventSubscriberInterface {
     $route_names = [
       'entity.user.cancel_form',
       'data_policy.data_policy',
+      'system.403',
       'system.404',
       'system.batch_page.html',
       'system.batch_page.json',
       'user.cancel_confirm',
       'user.logout',
+      'entity_sanitizer_image_fallback.generator',
     ];
 
     if (in_array($route_name, $route_names, TRUE)) {


### PR DESCRIPTION
### Problem/Motivation
The Data Policy module by default takes over a destination when this is set while it's not respecting the original redirect.
Currently there is no way to override the destination or alter the destination.

### Proposed resolution
We need to add a alter destination hook which allows the developer to override the destination with the original source.

### Issue tracker
https://www.drupal.org/project/data_policy/issues/3059927

### HTT
- [ ] Using a new account (or make sure there is a new data policy) login.
- [ ] See you are redirected to the data policy agreement form after a successful login.