### PR TITLE
#3065415 - added new method that reads out the data policy state.

### DIFF
--- a/src/DataPolicyConsentManager.php
+++ b/src/DataPolicyConsentManager.php
@@ -72,6 +72,13 @@ class DataPolicyConsentManager implements DataPolicyConsentManagerInterface {
   /**
    * {@inheritdoc}
    */
+  public function hasGivenConsent() {
+    return $this->getState();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function addCheckbox(array &$form) {
     $form['#attached']['library'][] = 'core/drupal.dialog.ajax';
 

--- a/src/DataPolicyConsentManagerInterface.php
+++ b/src/DataPolicyConsentManagerInterface.php
@@ -18,6 +18,14 @@ interface DataPolicyConsentManagerInterface {
   public function needConsent();
 
   /**
+   * Check if the user has given consent to the latest default data policy.
+   *
+   * @return bool|int
+   *   FALSE if the user doesn't have given consent.
+   */
+  public function hasGivenConsent();
+
+  /**
    * Add checkbox to form which allow user give consent on data policy.
    *
    * @param array $form


### PR DESCRIPTION
### Motivation
Data Policy Manager Service doesn't have a method to check if the user accepted the new default and therefor a lot of duplicate code is needed.

### Proposed resolution
Add a method that makes the Data Policy consent state public.

### Issue tracker
https://www.drupal.org/project/data_policy/issues/3065415